### PR TITLE
Fix 1xx module docstring range

### DIFF
--- a/src/response_codes/_1xx_informational.py
+++ b/src/response_codes/_1xx_informational.py
@@ -1,7 +1,7 @@
 """1xx Informational HTTP status codes.
 
 This module contains HTTP status code exceptions for informational responses
-(100-102).
+(100-103).
 """
 
 from ._core import HTTPStatus


### PR DESCRIPTION
## Summary
- correct the informational module docstring range from 100-102 to 100-103

## Validation
- poe ruff
- pytest -q -p no:cacheprovider --no-cov