### PR TITLE
feat: add HTTP status category predicate helpers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.11
+    rev: v0.15.7
     hooks:
       - id: ruff
         name: "lint with ruff"
@@ -19,15 +19,17 @@ repos:
         name: "format with ruff"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.19.1" # Use the sha / tag you want to point at
+    rev: v1.19.1 # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         name: "run mypy"
-        # additional_dependencies:
+        args: ["--strict", "--python-version", "3.10"]
+        additional_dependencies:
+          - pytest
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.9.24
+    rev: 0.10.12
     hooks:
       # Update the uv lockfile
       - id: uv-lock

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ uv add http-response-codes
 - Hashable - use as dictionary keys or in sets
 - Type hints included
 - Predefined groups of related status codes
+- Category predicate helpers (`is_success`, `is_client_error`, `is_server_error`, etc.)
 - Detailed descriptions for each status code
 - Zero dependencies
 
@@ -91,6 +92,27 @@ if status_code in HTTP_CLIENT_ERRORS:
 > [!NOTE]
 > Built-in status groups are exported as read-only mappings. You can look up
 > and iterate values normally, but mutation operations are not supported.
+
+### Status Category Helpers
+
+Category predicate helpers: `is_informational`, `is_success`, `is_redirection`,
+`is_client_error`, `is_server_error`.
+They accept an `int`, a status class, or a status instance; unsupported types
+raise `TypeError`.
+
+Practical example:
+
+```python
+from response_codes import HTTP_202_ACCEPTED, HTTP_429_TOO_MANY_REQUESTS, is_success, is_client_error
+is_success(202)  # True
+is_success(HTTP_202_ACCEPTED)  #True
+is_success(HTTP_202_ACCEPTED())  # True
+is_success(302)  # False
+is_client_error(HTTP_429_TOO_MANY_REQUESTS)  # True
+is_client_error(404)  # True
+is_client_error(3.14)  # TypeError: value must be int or HTTPStatus
+is_client_error(None)  # TypeError: value must be int or HTTPStatus
+```
 
 ### Advanced Comparison Features
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Practical example:
 ```python
 from response_codes import HTTP_202_ACCEPTED, HTTP_429_TOO_MANY_REQUESTS, is_success, is_client_error
 is_success(202)  # True
-is_success(HTTP_202_ACCEPTED)  #True
+is_success(HTTP_202_ACCEPTED)  # True
 is_success(HTTP_202_ACCEPTED())  # True
 is_success(302)  # False
 is_client_error(HTTP_429_TOO_MANY_REQUESTS)  # True

--- a/src/response_codes/__init__.py
+++ b/src/response_codes/__init__.py
@@ -121,11 +121,25 @@ from ._groups import (
     HTTP_SUCCESS,
 )
 
+# HTTP status categories
+from ._is_category import (
+    is_client_error,
+    is_informational,
+    is_redirection,
+    is_server_error,
+    is_success,
+)
+
 __all__ = [
     # Core classes and utilities
     "HTTPStatus",
     "HTTPStatusMeta",
     "create_status_group",
+    "is_informational",
+    "is_success",
+    "is_redirection",
+    "is_client_error",
+    "is_server_error",
     # 1xx Informational
     "HTTP_100_CONTINUE",
     "HTTP_101_SWITCHING_PROTOCOLS",

--- a/src/response_codes/_core.py
+++ b/src/response_codes/_core.py
@@ -178,4 +178,8 @@ def create_status_group(
     }
 
 
-__all__ = ["HTTPStatus", "HTTPStatusMeta", "create_status_group"]
+__all__ = [
+    "HTTPStatus",
+    "HTTPStatusMeta",
+    "create_status_group",
+]

--- a/src/response_codes/_is_category.py
+++ b/src/response_codes/_is_category.py
@@ -1,0 +1,84 @@
+"""Helpers for checking HTTP status categories by predefined groups."""
+
+from __future__ import annotations
+
+from typing import Union
+
+from ._core import HTTPStatus
+
+StatusValue = Union[int, type[HTTPStatus], HTTPStatus]
+
+_INFORMATIONAL_MIN, _INFORMATIONAL_MAX = 100, 199
+_SUCCESS_MIN, _SUCCESS_MAX = 200, 299
+_REDIRECTION_MIN, _REDIRECTION_MAX = 300, 399
+_CLIENT_ERROR_MIN, _CLIENT_ERROR_MAX = 400, 499
+_SERVER_ERROR_MIN, _SERVER_ERROR_MAX = 500, 599
+
+
+def _get_status_code(value: StatusValue) -> int:
+    """Extract numeric status code from an int/class/instance.
+
+    Args:
+        value: The input status value.
+
+    Returns:
+        The numeric HTTP status code.
+
+    Raises:
+        TypeError: If `value` is not an supported int/class/instance.
+    """
+    error_message = "value must be int or HTTPStatus"
+
+    # Note: `bool` is a subclass of `int`, but it's not a valid status code.
+    if isinstance(value, bool):
+        raise TypeError(error_message)
+
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, HTTPStatus):
+        return value.status_code
+
+    if isinstance(value, type) and issubclass(value, HTTPStatus):
+        return value.status_code
+
+    raise TypeError(error_message)
+
+
+def is_informational(value: StatusValue) -> bool:
+    """Return True if `value` is in the informational 1xx range."""
+    code = _get_status_code(value)
+    return _INFORMATIONAL_MIN <= code <= _INFORMATIONAL_MAX
+
+
+def is_success(value: StatusValue) -> bool:
+    """Return True if `value` is in the success 2xx range."""
+    code = _get_status_code(value)
+    return _SUCCESS_MIN <= code <= _SUCCESS_MAX
+
+
+def is_redirection(value: StatusValue) -> bool:
+    """Return True if `value` is in the redirection 3xx range."""
+    code = _get_status_code(value)
+    return _REDIRECTION_MIN <= code <= _REDIRECTION_MAX
+
+
+def is_client_error(value: StatusValue) -> bool:
+    """Return True if `value` is in the client error 4xx range."""
+    code = _get_status_code(value)
+    return _CLIENT_ERROR_MIN <= code <= _CLIENT_ERROR_MAX
+
+
+def is_server_error(value: StatusValue) -> bool:
+    """Return True if `value` is in the server error 5xx range."""
+    code = _get_status_code(value)
+    return _SERVER_ERROR_MIN <= code <= _SERVER_ERROR_MAX
+
+
+__all__ = [
+    "is_client_error",
+    "is_informational",
+    "is_redirection",
+    "is_server_error",
+    "is_success",
+]

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,161 @@
+"""Tests for HTTP status category helpers (is_* functions)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+import pytest
+
+from response_codes import (
+    HTTP_103_EARLY_HINTS,
+    HTTP_200_OK,
+    HTTP_422_UNPROCESSABLE_ENTITY,
+    HTTP_500_INTERNAL_SERVER_ERROR,
+    is_client_error,
+    is_informational,
+    is_redirection,
+    is_server_error,
+    is_success,
+)
+
+
+class TestStatusCategories:
+    """Tests for HTTP status category helpers."""
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            (99, False),
+            (100, True),
+            (101, True),
+            (102, True),
+            (103, True),
+            (104, True),
+            (199, True),
+            (200, False),
+        ],
+    )
+    def test_is_informational_int_bounds(
+        self, code: int, expected: object
+    ) -> None:
+        """Return True only for values in the 100-199 range."""
+        assert is_informational(code) is expected
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            (199, False),
+            (200, True),
+            (201, True),
+            (202, True),
+            (203, True),
+            (226, True),
+            (250, True),
+            (299, True),
+            (300, False),
+        ],
+    )
+    def test_is_success_int_bounds(self, code: int, expected: object) -> None:
+        """Return True only for values in the 200-299 range."""
+        assert is_success(code) is expected
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            (299, False),
+            (300, True),
+            (301, True),
+            (302, True),
+            (307, True),
+            (308, True),
+            (306, True),
+            (399, True),
+            (400, False),
+        ],
+    )
+    def test_is_redirection_int_bounds(
+        self, code: int, expected: object
+    ) -> None:
+        """Return True only for values in the 300-399 range."""
+        assert is_redirection(code) is expected
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            (399, False),
+            (400, True),
+            (401, True),
+            (402, True),
+            (403, True),
+            (404, True),
+            (405, True),
+            (408, True),
+            (422, True),
+            (429, True),
+            (499, True),
+            (500, False),
+        ],
+    )
+    def test_is_client_error_int_bounds(
+        self, code: int, expected: object
+    ) -> None:
+        """Return True only for values in the 400-499 range."""
+        assert is_client_error(code) is expected
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            (499, False),
+            (500, True),
+            (501, True),
+            (502, True),
+            (503, True),
+            (504, True),
+            (509, True),
+            (511, True),
+            (599, True),
+            (600, False),
+        ],
+    )
+    def test_is_server_error_int_bounds(
+        self, code: int, expected: object
+    ) -> None:
+        """Return True only for values in the 500-599 range."""
+        assert is_server_error(code) is expected
+
+    @pytest.mark.parametrize(
+        ("predicate", "value"),
+        [
+            (is_informational, HTTP_103_EARLY_HINTS),
+            (is_success, HTTP_200_OK),
+            (is_success, HTTP_200_OK()),
+            (is_client_error, HTTP_422_UNPROCESSABLE_ENTITY),
+            (is_client_error, HTTP_422_UNPROCESSABLE_ENTITY()),
+            (is_server_error, HTTP_500_INTERNAL_SERVER_ERROR()),
+        ],
+    )
+    def test_is_accepts_status_classes_and_instances(
+        self, predicate: Callable[[object], bool], value: object
+    ) -> None:
+        """Accept HTTPStatus subclasses and instances as input."""
+        assert predicate(value) is True
+
+    @pytest.mark.parametrize(
+        ("predicate", "value"),
+        [
+            (is_informational, "404"),
+            (is_success, None),
+            (is_client_error, []),
+            (is_server_error, 3.14),
+            (is_redirection, True),
+        ],
+    )
+    def test_invalid_types_raise_typeerror(
+        self, predicate: Callable[[object], bool], value: object
+    ) -> None:
+        """Raise TypeError for unsupported input types."""
+        with pytest.raises(TypeError):
+            predicate(value)


### PR DESCRIPTION
- Added: New `_is_category` module with `is_informational`, `is_success`, `is_redirection`, `is_client_error`, and `is_server_error`, plus new `tests/test_categories.py` for predicate behavior and input validation.
- Changed: Exported the new `is_*` functions from `src/response_codes/__init__.py` and reformatted `__all__ in src/response_codes/_core.py`

closed issue #17  